### PR TITLE
Floating point numbers and implicit multiplication + is_3d flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
+checksum = "78848718ee1255a2485d1309ad9cdecfc2e7d0362dd11c6829364c6b35ae1bc7"
 dependencies = [
  "cc",
  "libc",
@@ -105,9 +105,9 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cc"
-version = "1.0.50"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
 
 [[package]]
 name = "cfg-if"
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "jpeg-decoder"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0256f0aec7352539102a9efbcb75543227b7ab1117e0f95450023af730128451"
+checksum = "5b47b4c4e017b01abdc5bcc126d2d1002e5a75bbe3ce73f9f4f311a916363704"
 dependencies = [
  "byteorder",
 ]
@@ -542,7 +542,7 @@ checksum = "0c8b15b261814f992e33760b1fca9fe8b693d8a65299f20c9901688636cfb746"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -920,7 +920,7 @@ checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -987,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
@@ -999,7 +999,7 @@ dependencies = [
 [[package]]
 name = "three-d"
 version = "0.1.0"
-source = "git+https://github.com/frankplus/three-d#5dfdcc37ab6a1c79c2d0a7b7503da015ef1ef23d"
+source = "git+https://github.com/frankplus/three-d#f442e52f03d7ff663aa12afa8fbc91715e516b11"
 dependencies = [
  "bincode",
  "cgmath",
@@ -1078,7 +1078,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "wasm-bindgen-shared",
 ]
 
@@ -1100,7 +1100,7 @@ checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1198,9 +1198,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
  "winapi",
 ]
@@ -1254,6 +1254,6 @@ checksum = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb76e5c421bbbeb8924c60c030331b345555024d56261dae8f3e786ed817c23"
+checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -13,14 +13,23 @@ pub enum Operation {
 // it is a program to be run in a stack machine
 pub struct Expression {
     ops: Vec<Operation>,
+    // This flag indicates the need
+    // to plot the function in the 3d space
+    is_3d: bool,
 }
 
 impl Expression {
-    pub fn new(ops: Vec<Operation>) -> Expression {
+    pub fn new(ops: Vec<Operation>, is_3d: bool) -> Expression {
         Expression {
             ops: ops,
+            is_3d: is_3d,
         }
     }
+
+    pub fn is_3d(&self) -> bool {
+        self.is_3d
+    }
+
     pub fn eval(&self, input: InputSpace) -> Number {
         let mut stack = Vec::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,8 @@ mod expression;
 use three_d::*;
 
 fn main() {
-    let get_input = || {String::from("x^2/5 + y^2/5")};
+    let get_input = || {String::from("x^2/5 *  y^2/5")};
+    let get_input = || {String::from("2x^2 + 3sin(x)")};
     start_main(get_input);
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,7 @@ mod expression;
 use three_d::*;
 
 fn main() {
-    let get_input = || {String::from("x^2/5 *  y^2/5")};
-    let get_input = || {String::from("2x^2 + 3sin(x)")};
+    let get_input = || {String::from("x^2/5 + y^2/5")};
     start_main(get_input);
 }
 

--- a/src/plotter3d.rs
+++ b/src/plotter3d.rs
@@ -1,6 +1,6 @@
 use three_d::*;
 use crate::operator_descr::{OperatorTable, default_operator_table};
-use crate::parser::Parser;
+use crate::parser;
 use crate::expression::Expression;
 use three_d::Program;
 
@@ -35,7 +35,7 @@ impl Plotter3d {
             include_str!("../assets/shaders/color.frag")).unwrap();
 
         let operator_table = default_operator_table();
-        let expression = Parser::new(input, &operator_table).parse().unwrap();
+        let expression = parser::parse(input, &operator_table).unwrap();
         let camera = Camera {position: (0.0, 0.0, 0.0), size: 10.0};
         let plot = Plot::new(gl, &expression, RESOLUTION, &camera);
         let projection = three_d::Camera::new_perspective(gl, vec3(10.0, 10.0, 10.0), vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 1.0),
@@ -53,7 +53,7 @@ impl Plotter3d {
     }
 
     pub fn set_expression(&mut self, gl: &Gl, input: &str) {
-        let expr = Parser::new(input, &self.operator_table).parse();
+        let expr = parser::parse(input, &self.operator_table);
         match expr {
             Ok(expr) => self.expression = expr,
             Err(_) => ()


### PR DESCRIPTION
Hi, with this PR the parser is going to be able to parse floating point numbers and support implicit multiplication syntax e.g. 2x + 3.

Also I added a new flag in Expression that indicates whether it contains the Y variable and thus
requires to be rendered in 3d.
Please note that in the current version even functions like f = 3y + 1, which could be rendered in 2d
are marked as necessitating 3d rendering, this is probably what we want though, since if we want
to render that function in 2d we can equally plot f = 3x + 1 and we agreed that it's not actually useful
watching functions like f = 3x + 1 rendered in 3d [if you really want to, use the y in place of x and rotate the resulting plot]